### PR TITLE
Add file picking buttons

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -14,6 +14,10 @@
     </Window.SystemBackdrop>
 
     <Grid>
-
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="12">
+            <Button x:Name="AddSourceButton" Content="Add Source File" Click="OnAddSourceFileClick" />
+            <Button x:Name="AddCheckButton" Content="Add File To Check" Click="OnAddFileToCheckClick" />
+            <Button x:Name="StartButton" Content="Start" Click="OnStartClick" />
+        </StackPanel>
     </Grid>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -12,6 +12,8 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using Windows.Storage.Pickers;
+using WinRT.Interop;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -23,9 +25,43 @@ namespace T_Numbers_Check
     /// </summary>
     public sealed partial class MainWindow : Window
     {
+        private string? _sourceFilePath;
+        private string? _fileToCheckPath;
+
         public MainWindow()
         {
             InitializeComponent();
+        }
+
+        private async void OnAddSourceFileClick(object sender, RoutedEventArgs e)
+        {
+            var picker = new FileOpenPicker();
+            picker.FileTypeFilter.Add(".xlsx");
+            picker.FileTypeFilter.Add(".xls");
+            InitializeWithWindow.Initialize(picker, WindowNative.GetWindowHandle(this));
+            var file = await picker.PickSingleFileAsync();
+            if (file != null)
+            {
+                _sourceFilePath = file.Path;
+            }
+        }
+
+        private async void OnAddFileToCheckClick(object sender, RoutedEventArgs e)
+        {
+            var picker = new FileOpenPicker();
+            picker.FileTypeFilter.Add(".xlsx");
+            picker.FileTypeFilter.Add(".xls");
+            InitializeWithWindow.Initialize(picker, WindowNative.GetWindowHandle(this));
+            var file = await picker.PickSingleFileAsync();
+            if (file != null)
+            {
+                _fileToCheckPath = file.Path;
+            }
+        }
+
+        private void OnStartClick(object sender, RoutedEventArgs e)
+        {
+            // TODO: Add processing logic using _sourceFilePath and _fileToCheckPath
         }
     }
 }


### PR DESCRIPTION
## Summary
- add three buttons to MainWindow for selecting Excel files and starting the process
- implement WinUI file pickers that store selected file paths

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68625c54f85083209364b7dd5089736f